### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,12 +96,12 @@
     <div class="container">
         <img src="geoalchemy.png" class="logo img-responsive">
 
-        <a class="box" href="http://geoalchemy-2.readthedocs.org/">
+        <a class="box" href="https://geoalchemy-2.readthedocs.io/">
             <h1>GeoAlchemy 2</h1>
             <h2>GeoAlchemy successor, simpler, PostGIS focused</h2>
         </a>
 
-        <a class="box" href="http://geoalchemy.readthedocs.org/">
+        <a class="box" href="https://geoalchemy.readthedocs.io/">
             <h1>GeoAlchemy</h1>
             <h2>GIS Support for SQLAlchemy</h2>
         </a>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
